### PR TITLE
Add AMD GPU support on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker compose up
 After you followed the quick start set-up below, change the Ollama credentials
 by using `http://host.docker.internal:11434/` as the host.
 
-### For AMD GPU users
+### For AMD GPU users on Linux
 
 ```
 git clone https://github.com/n8n-io/self-hosted-ai-starter-kit.git

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ docker compose up
 After you followed the quick start set-up below, change the Ollama credentials
 by using `http://host.docker.internal:11434/` as the host.
 
+### For AMD GPU users
+
+```
+git clone https://github.com/n8n-io/self-hosted-ai-starter-kit.git
+cd self-hosted-ai-starter-kit
+docker compose --profile gpu-amd up
+```
+
 ### For everyone else
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,14 @@ services:
               count: 1
               capabilities: [gpu]
 
+  ollama-gpu-amd:
+    profiles: ["gpu-amd"]
+    <<: *service-ollama
+    image: ollama/ollama:rocm
+    devices:
+      - "/dev/kfd"
+      - "dev/dri"
+
   ollama-pull-llama-cpu:
     profiles: ["cpu"]
     <<: *init-ollama
@@ -125,3 +133,10 @@ services:
     <<: *init-ollama
     depends_on:
       - ollama-gpu
+
+  ollama-pull-llama-gpu-amd:
+    profiles: [gpu-amd]
+    <<: *init-ollama
+    image: ollama/ollama:rocm
+    depends_on:
+     - ollama-gpu-amd


### PR DESCRIPTION
This PR adds the capability to run ollama on AMD GPU's on Linux.

I Tested it on ARCH Linux with an AMD Radeon RX 6800 XT