### PR TITLE
fix: Update llama version to 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ After completing the installation steps above, simply follow the steps below to 
    <http://localhost:5678/workflow/srOnR8PAY3u4RSwb>
 3. Select **Test workflow** to start running the workflow.
 4. If this is the first time you’re running the workflow, you may need to wait
-   until Ollama finishes downloading Llama3.1. You can inspect the docker
+   until Ollama finishes downloading Llama3.2. You can inspect the docker
    console logs to check on the progress.
 
 To open n8n at any time, visit <http://localhost:5678/> in your browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ x-init-ollama: &init-ollama
   entrypoint: /bin/sh
   command:
     - "-c"
-    - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull llama3.1"
+    - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull llama3.2"
 
 services:
   postgres:

--- a/n8n/backup/workflows/srOnR8PAY3u4RSwb.json
+++ b/n8n/backup/workflows/srOnR8PAY3u4RSwb.json
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "model": "llama3.1:latest",
+        "model": "llama3.2:latest",
         "options": {}
       },
       "id": "3dee878b-d748-4829-ac0a-cfd6705d31e5",


### PR DESCRIPTION
## Summary

This PR updates the llama version used by default to the more up-to-date `llama3.2`

## Related Linear tickets

- https://linear.app/n8n/issue/AI-252/select-up-to-date-models-by-default