### PR TITLE
Changing to podman-compatible from docker compose's legacy 'links' 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ x-n8n: &service-n8n
     - N8N_PERSONALIZATION_ENABLED=false
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
-  links:
-    - postgres
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest
@@ -46,8 +44,11 @@ x-init-ollama: &init-ollama
 services:
   postgres:
     image: postgres:16-alpine
+    hostname: postgres
     networks: ['demo']
     restart: unless-stopped
+    ports:
+      - 5432:5432
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
@@ -62,6 +63,7 @@ services:
 
   n8n-import:
     <<: *service-n8n
+    hostname: n8n-import
     container_name: n8n-import
     entrypoint: /bin/sh
     command:
@@ -75,6 +77,7 @@ services:
 
   n8n:
     <<: *service-n8n
+    hostname: n8n
     container_name: n8n
     restart: unless-stopped
     ports:
@@ -91,6 +94,7 @@ services:
 
   qdrant:
     image: qdrant/qdrant
+    hostname: qdrant
     container_name: qdrant
     networks: ['demo']
     restart: unless-stopped
@@ -101,10 +105,12 @@ services:
 
   ollama-cpu:
     profiles: ["cpu"]
+    hostname: ollama-cpu
     <<: *service-ollama
 
   ollama-gpu:
     profiles: ["gpu-nvidia"]
+    hostname: ollama-gpu
     <<: *service-ollama
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ x-init-ollama: &init-ollama
   entrypoint: /bin/sh
   command:
     - "-c"
-    - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull llama3.2"
+    - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull llama3.2; OLLAMA_HOST=ollama:11434 ollama pull nomic-embed-text;"
 
 services:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,12 +105,10 @@ services:
 
   ollama-cpu:
     profiles: ["cpu"]
-    hostname: ollama-cpu
     <<: *service-ollama
 
   ollama-gpu:
     profiles: ["gpu-nvidia"]
-    hostname: ollama-gpu
     <<: *service-ollama
     deploy:
       resources:


### PR DESCRIPTION
GREAT WORK!!

Basically this makes the docker compose  podman-compatible. It's a small change and I checked it's still working in both Docker and podman.

The 'Links' feature is legacy for docker, see: [Compose reference (legacy)](https://github.com/docker/compose/blob/v1/docs/Compose%20file%20reference%20(legacy)/compose-versioning.md#version-2):

"By default, every container joins an application-wide default network, and is discoverable at a hostname that's the same as the service name. This means [links](https://github.com/docker/compose/blob/v1/docs/Compose%20file%20reference%20(legacy)/compose-file-v2.md#links) are largely unnecessary. For more details, see [Networking in Compose](https://docs.docker.com/compose/networking/)."