### PR TITLE
Fix: Add Chromium support for browser-dependent community nodes

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,42 @@
+name: Docker Compose Test
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'docker-compose.yml'
+      - 'Dockerfile.n8n'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'docker-compose.yml'
+      - 'Dockerfile.n8n'
+  workflow_dispatch:
+
+jobs:
+  test-docker-compose:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create env file
+        run: |
+          echo "POSTGRES_USER=n8n" > .env
+          echo "POSTGRES_PASSWORD=n8n" >> .env
+          echo "POSTGRES_DB=n8n" >> .env
+          echo "N8N_ENCRYPTION_KEY=randomkey" >> .env
+          echo "N8N_USER_MANAGEMENT_JWT_SECRET=randomsecret" >> .env
+
+      - name: Test Docker Compose
+        run: |
+          docker compose up -d
+          sleep 30
+          docker compose ps
+          docker compose logs
+          docker compose down

--- a/Dockerfile.n8n
+++ b/Dockerfile.n8n
@@ -1,0 +1,20 @@
+FROM n8nio/n8n:latest
+
+USER root
+
+# Install dependency for chrome browser
+RUN apk add --no-cache \
+    chromium \
+    chromium-chromedriver \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
+
+# Set global parameter
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,13 @@ x-n8n: &service-n8n
     - N8N_PERSONALIZATION_ENABLED=false
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
+    - NODE_FUNCTION_ALLOW_EXTERNAL=*
+    - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
   links:
     - postgres
+  build:
+    context: .
+    dockerfile: Dockerfile.n8n
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest


### PR DESCRIPTION
### Problem (Bug)
- Some n8n's community plugins **only work** in Chrome-based browsers. (ex. [n8n-nodes-youtube-transcription](https://www.npmjs.com/package/n8n-nodes-youtube-transcription))
- As a result, some nodes crash in non-chrome browsers.

### Solution
- Added Dockerfile.n8n with **Chromium** and Puppeteer setup

## Change Log
1. Added Dockerfile.n8n
- Added Chromium dependencies for YouTube Transcript node
- Configured Puppeteer settings for Docker environment

2. Added GitHub Actions Workflow
- Implemented **Docker Compose testing**
- Automated container status and log verification