### PR TITLE
For Mac users running OLLAMA locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,24 @@ cd self-hosted-ai-starter-kit
 docker compose up
 ```
 
-After you followed the quick start set-up below, change the Ollama credentials
-by using `http://host.docker.internal:11434/` as the host.
+##### For Mac users running OLLAMA locally
+
+If you're running OLLAMA locally on your Mac (not in Docker), you need to modify the OLLAMA_HOST environment variable
+in the n8n service configuration. Update the x-n8n section in your Docker Compose file as follows:
+
+```yaml
+x-n8n: &service-n8n
+  # ... other configurations ...
+  environment:
+    # ... other environment variables ...
+    - OLLAMA_HOST=host.docker.internal:11434
+```
+
+Additionally, after you see "Editor is now accessible via: <http://localhost:5678/>":
+
+1. Head to <http://localhost:5678/home/credentials>
+2. Click on "Local Ollama service"
+3. Change the base URL to "http://host.docker.internal:11434/"
 
 ### For everyone else
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ x-n8n: &service-n8n
     - N8N_PERSONALIZATION_ENABLED=false
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
+    - OLLAMA_HOST=ollama:11434
   links:
     - postgres
 
@@ -41,7 +42,7 @@ x-init-ollama: &init-ollama
   entrypoint: /bin/sh
   command:
     - "-c"
-    - "sleep 3; OLLAMA_HOST=ollama:11434 ollama pull llama3.1"
+    - "sleep 3; ollama pull llama3.1"
 
 services:
   postgres:


### PR DESCRIPTION
Having just gone through getting this to work, I wanted to add back this nugget for the next person.

Fixes:
- Moves the OLLAMA_HOST set in n8n environment.
- Provides instructions on how to modify OLLAMA_HOST when using local Ollama on Mac.
- Provides clearer instructions on how to change "Local Ollama service" credentials.