### PR TITLE
Include .env in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ x-n8n: &service-n8n
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - OLLAMA_HOST=ollama:11434
+  env_file:
+    - .env
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest


### PR DESCRIPTION
docker-compose needs .env file in order to run properly, but its variables are not included in n8n if they're not explicitly referenced here.
See https://community.n8n.io/t/oauth-redirect-url-stuck-with-localhost-and-consent-windows-complains-on-error-400-redirect-uri-mismatch/92609 for reference. 