### PR TITLE
Fix typo in AMD GPU command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker compose --profile gpu-nvidia up
 ```
 git clone https://github.com/n8n-io/self-hosted-ai-starter-kit.git
 cd self-hosted-ai-starter-kit
-docker compose --profile gpu-amd up
+docker compose --profile gpu_amd up
 ```
 
 #### For Mac / Apple Silicon users


### PR DESCRIPTION
This PR corrects a small but impactful typo in the docker compose command used to run the AMD GPU profile for the self-hosted AI starter kit (and/or n8n depending on the repo context).

The documentation currently instructs users to run: docker compose --profile gpu-amd up

However, the actual profile defined in the docker-compose.yml file is:  gpu_amd

This mismatch causes Docker Compose to attempt to start containers without the correct profile configuration, which leads to misleading and confusing errors like:

Error response from daemon: error gathering device information while adding custom device "/dev/kfd": no such file or directory

This can make users think there's a ROCm or driver issue, when in fact the profile name is simply incorrect.

The correct command should be:
docker compose --profile gpu_amd up


🧪 Tested
Verified locally — using the correct gpu_amd profile name launches the containers successfully with no GPU-related errors.