### PR TITLE
Refactor docker-compose.yml to simplify .env file inclusion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ x-n8n: &service-n8n
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - OLLAMA_HOST=${OLLAMA_HOST:-ollama:11434}
   env_file:
-    - path: .env
-      required: true
+    - .env
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest


### PR DESCRIPTION
When I try to use the quick start guide on mac, the command: `docker compose --profile cpu up` will throw an error: `services.n8n.env_file.0 must be a string`. 

The solution for this is to state the env files as a path without the `required` parameter.