### PR TITLE
Change deprecated docker command in upgrading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,21 +146,21 @@ language model and Qdrant as your vector store.
 
 ```bash
 docker compose --profile gpu-nvidia pull
-docker compose up --no-start && docker compose --profile gpu-nvidia up
+docker compose --profile gpu-nvidia up
 ```
 
 * ### For Mac / Apple Silicon users
 
 ```bash
 docker compose pull
-docker compose up --no-start && docker compose up
+docker compose up
 ```
 
 * ### For Non-GPU setups:
 
 ```bash
 docker compose --profile cpu pull
-docker compose up --no-start && docker compose --profile cpu up
+docker compose --profile cpu up
 ```
 
 ## 👓 Recommended reading

--- a/README.md
+++ b/README.md
@@ -146,21 +146,21 @@ language model and Qdrant as your vector store.
 
 ```bash
 docker compose --profile gpu-nvidia pull
-docker compose create && docker compose --profile gpu-nvidia up
+docker compose up --no-start && docker compose --profile gpu-nvidia up
 ```
 
 * ### For Mac / Apple Silicon users
 
 ```bash
 docker compose pull
-docker compose create && docker compose up
+docker compose up --no-start && docker compose up
 ```
 
 * ### For Non-GPU setups:
 
 ```bash
 docker compose --profile cpu pull
-docker compose create && docker compose --profile cpu up
+docker compose up --no-start && docker compose --profile cpu up
 ```
 
 ## 👓 Recommended reading


### PR DESCRIPTION
Running `docker-compose create` yields a warning: 

`The create command is deprecated. Use the up command with the --no-start flag instead.`

This commit fixes the upgrade instructions.