### PR TITLE
.env file error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,8 @@ x-n8n: &service-n8n
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - OLLAMA_HOST=${OLLAMA_HOST:-ollama:11434}
-  env_file:
-    - path: .env
-      required: true
-
+  env_file: .env
+    
 x-ollama: &service-ollama
   image: ollama/ollama:latest
   container_name: ollama

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
   qdrant_storage:
 
 networks:
-  demo:
+  demo: 
 
 x-n8n: &service-n8n
   image: n8nio/n8n:latest


### PR DESCRIPTION
With the default docker-compose file, ran into this error: 
"ERROR: The Compose file './docker-compose.yml' is invalid because:
services.n8n.env_file contains {"path": ".env", "required": "true"}, which is an invalid type, it should be a string
services.n8n-import.env_file contains {"path": ".env", "required": "true"}, which is an invalid type, it should be a string"

Replaced with "env_file: .env" and everything is working properly.