### PR TITLE
Ivan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+n8n/home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 volumes:
-  n8n_storage:
   postgres_storage:
   ollama_storage:
   qdrant_storage:
@@ -9,7 +8,7 @@ networks:
 
 x-n8n: &service-n8n
   image: n8nio/n8n:latest
-  networks: ['demo']
+  networks: ["demo"]
   environment:
     - DB_TYPE=postgresdb
     - DB_POSTGRESDB_HOST=postgres
@@ -26,8 +25,8 @@ x-n8n: &service-n8n
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest
+  networks: ["demo"]
   container_name: ollama
-  networks: ['demo']
   restart: unless-stopped
   ports:
     - 11434:11434
@@ -36,7 +35,7 @@ x-ollama: &service-ollama
 
 x-init-ollama: &init-ollama
   image: ollama/ollama:latest
-  networks: ['demo']
+  networks: ["demo"]
   container_name: ollama-pull-llama
   volumes:
     - ollama_storage:/root/.ollama
@@ -51,7 +50,7 @@ services:
   postgres:
     image: postgres:16-alpine
     hostname: postgres
-    networks: ['demo']
+    networks: ["demo"]
     restart: unless-stopped
     environment:
       - POSTGRES_USER
@@ -60,7 +59,11 @@ services:
     volumes:
       - postgres_storage:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}",
+        ]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -82,12 +85,13 @@ services:
   n8n:
     <<: *service-n8n
     hostname: n8n
-    container_name: n8n
+    container_name: n8n_selfhosted
+    networks: ["demo"]
     restart: unless-stopped
     ports:
       - 5678:5678
     volumes:
-      - n8n_storage:/home/node/.n8n
+      - ./n8n/home:/home/node/.n8n
       - ./n8n/demo-data:/demo-data
       - ./shared:/data/shared
     depends_on:
@@ -100,7 +104,7 @@ services:
     image: qdrant/qdrant
     hostname: qdrant
     container_name: qdrant
-    networks: ['demo']
+    networks: ["demo"]
     restart: unless-stopped
     ports:
       - 6333:6333
@@ -147,4 +151,4 @@ services:
     <<: *init-ollama
     image: ollama/ollama:rocm
     depends_on:
-     - ollama-gpu-amd
+      - ollama-gpu-amd

--- a/n8n/demo-data/workflows/srOnR8PAY3u4RSwb.json
+++ b/n8n/demo-data/workflows/srOnR8PAY3u4RSwb.json
@@ -22,7 +22,7 @@
       "id": "ce8c3da4-899c-4cc4-af73-8096c64eec64",
       "name": "Basic LLM Chain",
       "type": "@n8n/n8n-nodes-langchain.chainLlm",
-      "typeVersion": 1.3,
+      "typeVersion": 1.7,
       "position": [
         880,
         340

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+docker compose --profile gpu-nvidia up


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched n8n to a local bind mount for data and cleaned up docker-compose for simpler self-hosting. Added a helper script to start the stack with the NVIDIA GPU profile.

- **New Features**
  - Persist n8n data to ./n8n/home (added to .gitignore).
  - Added run.sh to launch with gpu-nvidia: docker compose --profile gpu-nvidia up.

- **Migration**
  - The n8n_storage volume was removed. If you used it, copy its data to ./n8n/home before starting. For example:
    - docker run --rm -v n8n_storage:/from -v "$(pwd)/n8n/home":/to alpine sh -c "cp -a /from/. /to/"

<sup>Written for commit 5dd47da0b0db9f66d9a7e3d22edfe4507ad9bdcc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

