### PR TITLE
Fix the broken link to Ollama Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker compose --profile gpu-nvidia up
 
 > [!NOTE]
 > If you have not used your Nvidia GPU with Docker before, please follow the
-> [Ollama Docker instructions](https://github.com/ollama/ollama/blob/main/docs/docker.md).
+> [Ollama Docker instructions](https://github.com/ollama/ollama/blob/main/docs/docker.mdx).
 
 ### For AMD GPU users on Linux
 


### PR DESCRIPTION
The GPU related config for Docker on Ollama repository has moved to a `.mdx`. This PR updates it accordingly to avoid headaches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken README link to Ollama’s Docker GPU setup by updating the URL from docs/docker.md to docs/docker.mdx, so users land on the correct instructions.

<sup>Written for commit 4c884d6f46927bfd2fe2cb5ac44704307ca0a54a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

