### PR TITLE
Skip demo import if workflows already exist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,14 @@ services:
     container_name: n8n-import
     entrypoint: /bin/sh
     command:
-      - "-c"
-      - "n8n import:credentials --separate --input=/demo-data/credentials && n8n import:workflow --separate --input=/demo-data/workflows"
+    - "-c"
+    - |
+      if [ -z "$(n8n list:workflow --onlyId)" ]; then
+        n8n import:credentials --separate --input=/demo-data/credentials && \
+        n8n import:workflow --separate --input=/demo-data/workflows
+      else
+        echo "Workflows exist, skipping import"
+      fi
     volumes:
       - ./n8n/demo-data:/demo-data
     depends_on:


### PR DESCRIPTION
Currently, every time compose starts it runs the import which either:
1) recreates the same demo workflow over and over
or 2) overwrites all changes made to demo workflow if it was used as a starting point 

This fix changes the import task to first check if there are any workflows in Postgres, and if there are, it skips the import.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip demo data import on startup when workflows already exist to prevent duplicates and accidental overwrites.
The import service now checks n8n list:workflow --onlyId and only runs the credentials/workflows import if the list is empty.

<sup>Written for commit 57cba0945da7dd95d2ba722b1c806846931b9ae1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

