### PR TITLE
Modified compse and env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ N8N_ENCRYPTION_KEY=super-secret-key
 N8N_USER_MANAGEMENT_JWT_SECRET=even-more-secret
 N8N_DEFAULT_BINARY_DATA_MODE=filesystem
 
+# External task runners (for Python/JavaScript in Code nodes)
+# Generate a secure random string for production
+N8N_RUNNERS_AUTH_TOKEN=your-runners-auth-token
+
 # For Mac users running OLLAMA locally
 # See https://github.com/n8n-io/self-hosted-ai-starter-kit?tab=readme-ov-file#for-mac--apple-silicon-users
 # OLLAMA_HOST=host.docker.internal:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ x-n8n: &service-n8n
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - OLLAMA_HOST=${OLLAMA_HOST:-ollama:11434}
+    - N8N_RUNNERS_ENABLED=true
+    - N8N_RUNNERS_MODE=external
+    - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=0.0.0.0
+    - N8N_RUNNERS_AUTH_TOKEN=${N8N_RUNNERS_AUTH_TOKEN}
+    - N8N_NATIVE_PYTHON_RUNNER=true
   env_file:
     - path: .env
       required: true
@@ -101,6 +106,22 @@ services:
         condition: service_healthy
       n8n-import:
         condition: service_completed_successfully
+
+  task-runners:
+    image: n8nio/runners:latest
+    container_name: n8n-runners
+    hostname: n8n-runners
+    networks: ['demo']
+    restart: unless-stopped
+    environment:
+      - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
+      - N8N_RUNNERS_AUTH_TOKEN=${N8N_RUNNERS_AUTH_TOKEN}
+    env_file:
+      - path: .env
+        required: true
+    depends_on:
+      n8n:
+        condition: service_started
 
   qdrant:
     image: qdrant/qdrant


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable external task runners for n8n Code nodes. Adds a `task-runners` service and compose env to run Python/JS code via `n8nio/runners:latest`, plus a new auth token in `.env.example`.

- **New Features**
  - Enable runners in external mode with broker listen on 0.0.0.0 and native Python runner.
  - Add `task-runners` service pointing to `http://n8n:5679` and using the shared auth token.
  - Add `N8N_RUNNERS_AUTH_TOKEN` to `.env.example` with guidance.

- **Migration**
  - Add a secure `N8N_RUNNERS_AUTH_TOKEN` to your `.env`.
  - Restart via docker-compose to launch `n8n` and `task-runners`.

<sup>Written for commit d6c21469b3109d803f5d12332bfced4204970b72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

