### PR TITLE
Add SearXNG service to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+searxng/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,3 +154,16 @@ services:
     image: ollama/ollama:rocm
     depends_on:
      - ollama-gpu-amd
+
+  searxng:
+    image: searxng/searxng:latest
+    hostname: searxng
+    container_name: searxng
+    networks: ['demo']
+    restart: unless-stopped
+    ports:
+      - 8080:8080
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      - SEARXNG_BASE_URL=http://searxng:8080/


### PR DESCRIPTION
Add SearXNG as a service on the demo network so it is reachable from n8n and other containers via http://searxng:8080/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `searxng` to `docker-compose` so services like `n8n` can use a local metasearch at http://searxng:8080/ on the `demo` network. Exposes 8080, mounts `./searxng` to `/etc/searxng`, sets SEARXNG_BASE_URL to the internal URL, and ignores the `searxng/` runtime config in `.gitignore`.

<sup>Written for commit a2bfffe048458c8559f594826b8c16e6ab1d0470. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

