### PR TITLE
Add Intel GPU support with LocalAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,3 @@ POSTGRES_DB=n8n
 N8N_ENCRYPTION_KEY=super-secret-key
 N8N_USER_MANAGEMENT_JWT_SECRET=even-more-secret
 N8N_DEFAULT_BINARY_DATA_MODE=filesystem
-
-# For Mac users running OLLAMA locally
-# See https://github.com/n8n-io/self-hosted-ai-starter-kit?tab=readme-ov-file#for-mac--apple-silicon-users
-# OLLAMA_HOST=host.docker.internal:11434
-
-

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ quickly get started with building self-hosted AI workflows.
 ✅ [**Self-hosted n8n**](https://n8n.io/) - Low-code platform with over 400
 integrations and advanced AI components
 
-✅ [**Ollama**](https://ollama.com/) - Cross-platform LLM platform to install
-and run the latest local LLMs
+✅ [**Ollama**](https://ollama.com/) - Cross-platform LLM platform used by the
+CPU, Nvidia, and AMD profiles
+
+✅ [**LocalAI**](https://localai.io/) - OpenAI-compatible local AI runtime used
+by the Intel GPU profile
 
 ✅ [**Qdrant**](https://qdrant.tech/) - Open-source, high performance vector
 store with an comprehensive API
@@ -90,16 +93,42 @@ cp .env.example .env # you should update secrets and passwords inside
 docker compose up
 ```
 
-##### For Mac users running OLLAMA locally
+##### For Mac users running Ollama locally
 
-If you're running OLLAMA locally on your Mac (not in Docker), you need to modify the OLLAMA_HOST environment variable
+After you see "Editor is now accessible via: <http://localhost:5678/>":
 
-1. Set OLLAMA_HOST to `host.docker.internal:11434` in your .env file. 
-2. Additionally, after you see "Editor is now accessible via: <http://localhost:5678/>":
+1. Head to <http://localhost:5678/home/credentials>.
+2. Open "Local OpenAI-compatible service".
+3. Change its Base URL to `http://host.docker.internal:11434/v1`.
 
-    1. Head to <http://localhost:5678/home/credentials>
-    2. Click on "Local Ollama service"
-    3. Change the base URL to "http://host.docker.internal:11434/"
+#### For Intel GPU users
+
+The `gpu-intel` profile uses LocalAI's official Intel GPU image and its
+OpenAI-compatible `/v1` API. No OpenAI cloud account or external API key is
+required.
+
+```bash
+git clone https://github.com/n8n-io/self-hosted-ai-starter-kit.git
+cd self-hosted-ai-starter-kit
+cp .env.example .env # you should update secrets and passwords inside
+docker compose --profile gpu-intel up
+```
+
+The host must expose `/dev/dri/renderD128`. The profile passes `/dev/dri` into
+`localai/localai:v4.7.1-gpu-intel`, persists model data, and serves the included
+`llama3.2` definition on port `11434`.
+
+Verify the API and GPU device:
+
+```bash
+curl --fail http://localhost:11434/readyz
+curl --fail http://localhost:11434/v1/models
+docker compose exec localai-intel test -e /dev/dri/renderD128
+```
+
+Readiness proves that LocalAI is serving. Confirm Intel offload separately in
+the LocalAI logs. The bundled workflow remains a Basic LLM Chain and does not
+claim agent or tool-calling compatibility.
 
 #### For everyone else
 
@@ -121,8 +150,8 @@ After completing the installation steps above, simply follow the steps below to 
    <http://localhost:5678/workflow/srOnR8PAY3u4RSwb>
 3. Click the **Chat** button at the bottom of the canvas, to start running the workflow.
 4. If this is the first time you’re running the workflow, you may need to wait
-   until Ollama finishes downloading Llama3.2. You can inspect the docker
-   console logs to check on the progress.
+   until the selected inference runtime finishes downloading Llama3.2. You can
+   inspect the Docker console logs to check on the progress.
 
 To open n8n at any time, visit <http://localhost:5678/> in your browser.
 
@@ -131,8 +160,8 @@ suite of basic and advanced AI nodes such as
 [AI Agent](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/),
 [Text classifier](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier/),
 and [Information Extractor](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.information-extractor/)
-nodes. To keep everything local, just remember to use the Ollama node for your
-language model and Qdrant as your vector store.
+nodes. The bundled workflow uses the OpenAI Chat Model against the selected
+local inference runtime and Qdrant as its vector store.
 
 > [!NOTE]
 > This starter kit is designed to help you get started with self-hosted AI
@@ -154,6 +183,13 @@ docker compose create && docker compose --profile gpu-nvidia up
 ```bash
 docker compose pull
 docker compose create && docker compose up
+```
+
+* ### For Intel GPU setups:
+
+```bash
+docker compose --profile gpu-intel pull
+docker compose create && docker compose --profile gpu-intel up
 ```
 
 * ### For Non-GPU setups:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ volumes:
   n8n_storage:
   postgres_storage:
   ollama_storage:
+  localai_models:
+  localai_data:
   qdrant_storage:
 
 networks:
@@ -27,7 +29,10 @@ x-n8n: &service-n8n
 x-ollama: &service-ollama
   image: ollama/ollama:latest
   container_name: ollama
-  networks: ['demo']
+  networks:
+    demo:
+      aliases:
+        - inference
   restart: unless-stopped
   ports:
     - 11434:11434
@@ -135,6 +140,36 @@ services:
     devices:
       - "/dev/kfd"
       - "/dev/dri"
+
+  localai-intel:
+    profiles: ["gpu-intel"]
+    image: localai/localai:v4.7.1-gpu-intel
+    container_name: localai-intel
+    networks:
+      demo:
+        aliases:
+          - inference
+    restart: unless-stopped
+    ports:
+      - 11434:11434
+    devices:
+      - "/dev/dri:/dev/dri"
+    environment:
+      LOCALAI_ADDRESS: ":11434"
+      LOCALAI_MODELS_PATH: /models
+      LOCALAI_DATA_PATH: /data
+      LOCALAI_F16: "true"
+      LOCALAI_THREADS: "1"
+    volumes:
+      - localai_models:/models
+      - localai_data:/data
+      - ./localai/models/llama3.2.yaml:/models/llama3.2.yaml:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/readyz"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 10m
 
   ollama-pull-llama-cpu:
     profiles: ["cpu"]

--- a/localai/models/llama3.2.yaml
+++ b/localai/models/llama3.2.yaml
@@ -1,0 +1,11 @@
+name: llama3.2
+backend: llama-cpp
+parameters:
+  model: ollama://llama3.2
+context_size: 4096
+threads: 1
+f16: true
+gpu_layers: 999
+# Intel SYCL can hang with mmap enabled.
+mmap: false
+description: Llama 3.2 served by LocalAI on Intel GPU

--- a/n8n/demo-data/credentials/xHuYe0MDGOs9IpBW.json
+++ b/n8n/demo-data/credentials/xHuYe0MDGOs9IpBW.json
@@ -2,16 +2,12 @@
   "createdAt": "2024-02-23T16:26:54.475Z",
   "updatedAt": "2024-02-23T16:26:58.928Z",
   "id": "xHuYe0MDGOs9IpBW",
-  "name": "Local Ollama service",
-  "data": "U2FsdGVkX18BVmjQBCdNKSrjr0GhmcTwMgG/rSWhncWtqOLPT62WnCIktky8RgM1PhH7vMkMc5EuUFIQA/eEZA==",
-  "type": "ollamaApi",
+  "name": "Local OpenAI-compatible service",
+  "data": "U2FsdGVkX18MwyupY0sBLpNzFM+DgdQukuXuRk5vVZ1zUFI1OhSrLR8jGXYOlqQJys+Bzz4Nt3KBH4jHqRI9CrJhKbdol1+J+3MRgozG5nbCwEdStcQgEGK1+F43+MEh",
+  "type": "openAiApi",
   "nodesAccess": [
     {
-      "nodeType": "@n8n/n8n-nodes-langchain.lmChatOllama",
-      "date": "2024-02-23T16:26:58.927Z"
-    },
-    {
-      "nodeType": "@n8n/n8n-nodes-langchain.lmOllama",
+      "nodeType": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "date": "2024-02-23T16:26:58.927Z"
     }
   ]

--- a/n8n/demo-data/workflows/srOnR8PAY3u4RSwb.json
+++ b/n8n/demo-data/workflows/srOnR8PAY3u4RSwb.json
@@ -30,21 +30,26 @@
     },
     {
       "parameters": {
-        "model": "llama3.2:latest",
+        "model": {
+          "__rl": true,
+          "value": "llama3.2",
+          "mode": "id"
+        },
+        "responsesApiEnabled": false,
         "options": {}
       },
       "id": "3dee878b-d748-4829-ac0a-cfd6705d31e5",
-      "name": "Ollama Chat Model",
-      "type": "@n8n/n8n-nodes-langchain.lmChatOllama",
-      "typeVersion": 1,
+      "name": "OpenAI Chat Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1.3,
       "position": [
         900,
         560
       ],
       "credentials": {
-        "ollamaApi": {
+        "openAiApi": {
           "id": "xHuYe0MDGOs9IpBW",
-          "name": "Local Ollama service"
+          "name": "Local OpenAI-compatible service"
         }
       }
     }
@@ -61,7 +66,7 @@
         ]
       ]
     },
-    "Ollama Chat Model": {
+    "OpenAI Chat Model": {
       "ai_languageModel": [
         [
           {


### PR DESCRIPTION
## Summary

- add an opt-in `gpu-intel` profile using LocalAI's official, versioned Intel GPU image
- use one local OpenAI-compatible credential and Basic LLM Chain across Ollama and LocalAI profiles
- add focused Intel setup, readiness, and GPU-device verification instructions

## Why this supersedes #74 and #77

Those proposals depended on a repository-owned Dockerfile built on the IPEX-LLM portable Ollama image. Maintainers reasonably declined to inherit an unofficial Ollama integration and its support burden.

This proposal has a materially different maintenance boundary:

- `localai/localai:v4.7.1-gpu-intel` is published and maintained by LocalAI
- this repository carries no inference Dockerfile, Intel driver build, or custom Ollama image
- Intel support is isolated behind the opt-in `gpu-intel` profile
- CPU, Nvidia, and AMD retain their existing Ollama services and default behavior

The Intel runtime is therefore a maintained LocalAI distribution, not the experimental custom IPEX/Ollama setup rejected previously.

## Validation

- n8n `2.31.6` credential and workflow import/export round-trip
- decrypted imported credential verified as `http://inference:11434/v1` with a placeholder local API key
- JSON/YAML parsing, profile alias assertions, UTF-8/NUL checks, and `git diff --check`
- `responsesApiEnabled: false` keeps the demo on `/v1/chat/completions`
- Basic LLM Chain only; no agent or tool-calling compatibility claim

The same official LocalAI Intel image is also running in production with:

- `/dev/dri/renderD128` exposed
- the Intel SYCL backend selected
- 28 model layers offloaded to the GPU
- healthy service state with zero restarts
- model discovery and OpenAI-compatible chat completions used successfully from n8n

Readiness proves that LocalAI is serving; the README still requires operators to confirm the render device and actual GPU offload rather than treating API readiness alone as proof of acceleration.

## Scope

- no OpenAI cloud dependency or real API key
- no custom inference image or Dockerfile
- no change to the default profile
- no tool-calling certification
